### PR TITLE
Fix for email showing null inside the jwt token claim

### DIFF
--- a/api/app/models/userModel.js
+++ b/api/app/models/userModel.js
@@ -264,7 +264,7 @@ const getOne = async ({
   });
 
   // Return password related fields only if includePasswordHash is set as true
-  const passwordHash = includePasswordHash ? 'password_hash, password_reset_token' : '';
+  const passwordHash = includePasswordHash ? 'password_hash, password_reset_token, ' : '';
 
   try {
     row = await (


### PR DESCRIPTION
Added a trailing comma when appending password related fields. Without the trailing comma, when requesting a new token, email field in the token will always be null.